### PR TITLE
Add pagination overlay for GitHub API (api.github.com 1.1.4)

### DIFF
--- a/github.com/api.github.com/1.1.4/pagination-overlay.yaml
+++ b/github.com/api.github.com/1.1.4/pagination-overlay.yaml
@@ -1,0 +1,39 @@
+overlay: 1.0.0
+info:
+  title: GitHub API Pagination Schemes
+  version: 1.0.0
+actions:
+  - target: $.components
+    update:
+      paginationSchemes:
+        nextLink:
+          type: nextLink
+          autoDetect:
+            matchQueryParams: false
+            matchBodyFields: false
+            matchHeaders: true
+            requireAll: false
+          request:
+            queryParameters:
+              per_page:
+                role: pageSize
+          response:
+            headers:
+              Link:
+                role: nextLink
+        pageNumber:
+          type: pageNumber
+          request:
+            queryParameters:
+              page:
+                role: page
+              per_page:
+                role: pageSize
+        cursor:
+          type: pageToken
+          request:
+            queryParameters:
+              cursor:
+                role: pageToken
+              per_page:
+                role: pageSize


### PR DESCRIPTION
Adds the first overlay to this collection: pagination schemes for the GitHub REST API.

## What's added

`github.com/api.github.com/1.1.4/pagination-overlay.yaml` — an OpenAPI overlay that adds `paginationSchemes` to the GitHub API spec, covering three pagination patterns:

| Scheme | Type | Auto-detect |
|--------|------|-------------|
| `nextLink` | `nextLink` | via `Link` response header |
| `pageNumber` | `pageNumber` | via `page` + `per_page` query params |
| `cursor` | `pageToken` | via `cursor` + `per_page` query params |

## Pagination patterns in the GitHub API

- **Link header** (primary): most list endpoints return a `Link` response header with `rel="next"`, `rel="prev"`, `rel="first"`, `rel="last"` URLs. The `nextLink` scheme handles this, with `per_page` as the page size control.
- **Page number**: the same list endpoints also accept `page` + `per_page` query params for offset-style pagination. The `pageNumber` scheme handles this.
- **Cursor**: enterprise/dependabot endpoints use an opaque `cursor` token. The `cursor` scheme handles this.

The `paginationSchemes` format follows the [openapi-pagination-extension spec](https://github.com/tubsproject/syncables/blob/main/openapi-pagination-extension.docx.pdf) as implemented by [michielbdejong/openapi-pagination-client](https://github.com/michielbdejong/openapi-pagination-client).

https://claude.ai/code/session_01VfT5fAcotF5EgAYiSSJJRe