### PR TITLE
Add Telnyx API pagination overlay

### DIFF
--- a/telnyx.com/2.0.0/pagination-overlay.yaml
+++ b/telnyx.com/2.0.0/pagination-overlay.yaml
@@ -1,0 +1,47 @@
+overlay: 1.0.0
+info:
+  title: Telnyx API Pagination Schemes
+  version: 1.0.0
+actions:
+  - target: $.components
+    update:
+      paginationSchemes:
+        pageNumber:
+          type: pageNumber
+          description: >
+            The Telnyx API uses page-number pagination across all list
+            endpoints. Pass `page[number]` (1-based, default 1) and
+            `page[size]` (default 20) as query parameters to control the
+            result window. Responses include a `meta` object with
+            `total_pages`, `total_records`, `page_number`, and `page_size`
+            fields.
+          request:
+            queryParameters:
+              page[number]:
+                role: page
+                description: >
+                  The page number to fetch. 1-based: the first page is 1,
+                  the second page is 2, and so on. Defaults to 1.
+              page[size]:
+                role: pageSize
+                description: >
+                  The number of items to return per page. Defaults to 20.
+          response:
+            bodyFields:
+              meta.total_pages:
+                role: totalPages
+                description: >
+                  The total number of pages available for this query.
+              meta.total_records:
+                role: totalCount
+                description: >
+                  The total number of records matching the query across all
+                  pages.
+              meta.page_number:
+                role: currentPage
+                description: >
+                  The current page number returned in this response.
+              meta.page_size:
+                role: pageSize
+                description: >
+                  The number of records per page returned in this response.


### PR DESCRIPTION
## Summary
- Adds a `pageNumber`-based pagination overlay for the Telnyx API v2.0.0
- Telnyx uses JSON:API-style pagination with `page[number]` and `page[size]` query parameters
- Response includes a `meta` object with `total_pages`, `total_records`, `page_number`, and `page_size`
- Source OAD: https://github.com/APIs-guru/openapi-directory/tree/main/APIs/telnyx.com

https://claude.ai/code/session_019r4dbPyDZo7SEnHMRtuhXZ