### PR TITLE
Fix Giphy pagination scheme: invalid type and response role

### DIFF
--- a/giphy.com/1.0/pagination-overlay.yaml
+++ b/giphy.com/1.0/pagination-overlay.yaml
@@ -7,7 +7,7 @@ actions:
     update:
       paginationSchemes:
         offset:
-          type: offset
+          type: pageNumber
           description: >
             Giphy list endpoints (search, trending) use offset-based pagination.
             Pass `limit` to control the page size and `offset` to skip results.
@@ -34,6 +34,6 @@ actions:
                 description: >
                   Number of items returned in the current response.
               pagination.offset:
-                role: offset
+                role: x-offset
                 description: >
                   The current offset position into the result set.


### PR DESCRIPTION
## Summary
- `type: offset` isn't a valid scheme type per the OpenAPI Pagination Schemes Extension spec (only `pageNumber | pageToken | nextLink` are allowed — `offset` is a *role*, not a type). Changed to `type: pageNumber`, matching how this repo's own `spotify.com/1.0.0/pagination-overlay.yaml` labels its equivalent offset-based scheme.
- The `pagination.offset` response field used `role: offset`, which isn't a valid *response* role (`offset` is request-only). Changed to the spec-compliant extension role `x-offset` so the semantic intent isn't lost.

Found while adding support for this extension to a downstream OpenAPI client/mock-server library ([localthought/syncables](https://github.com/localthought/syncables)) and running its scheme validator against every overlay it consumes — both errors caused this scheme to fail validation outright, so pagination support never actually engaged for Giphy.

## Test plan
- [x] Validated the fixed scheme against the extension's spec §9 rules (type enum, request/response role enums) using the validator in localthought/syncables — passes with zero errors (previously 2).
- [x] Confirmed no other field in this overlay is affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
